### PR TITLE
fix: dynamic nav offset and footer year check

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,18 +358,23 @@
   <!-- Minimal JS -->
   <script>
     // Current year in footer
-    document.getElementById('year').textContent = new Date().getFullYear();
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
 
-    // iPad: maintain focus/scroll target offset beneath sticky nav
+    // Maintain focus/scroll target offset beneath sticky nav
+    const nav = document.querySelector('.nav');
+    const navHeight = nav ? nav.offsetHeight : 0;
     for (const link of document.querySelectorAll('a[href^="#"]')) {
       link.addEventListener('click', function (e) {
         const id = this.getAttribute('href').slice(1);
         const el = document.getElementById(id);
         if (!el) return;
         e.preventDefault();
-        const y = el.getBoundingClientRect().top + window.scrollY - 70;
+        const y = el.getBoundingClientRect().top + window.scrollY - navHeight;
         window.scrollTo({top: y, behavior: 'smooth'});
-        history.pushState(null, "", "#" + id);
+        history.pushState(null, '', '#' + id);
       });
     }
   </script>


### PR DESCRIPTION
## Summary
- handle missing footer year element
- calculate sticky nav height dynamically for anchor scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a9187ad8832fb3842fee011dca2b