### PR TITLE
Refresh contact info and page background

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
     body{
       font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
       color:var(--ink);
-      background: linear-gradient(180deg, #f9fbff 0%, #fff 40%);
+      background:
+        url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 100 100"><g fill="%230e58ff0D"><circle cx="20" cy="20" r="8"/><circle cx="60" cy="15" r="8"/><circle cx="15" cy="60" r="8"/><circle cx="65" cy="65" r="8"/><path d="M40 40c-8 0-16 8-16 16 0 5 5 11 16 11s16-6 16-11c0-8-8-16-16-16z"/></g></svg>'),
+        linear-gradient(180deg, #f9fbff 0%, #fff 40%);
+      background-repeat: repeat, no-repeat;
+      background-attachment: fixed;
       -webkit-font-smoothing:antialiased;
       text-rendering:optimizeLegibility;
     }
@@ -193,7 +197,7 @@
         <a href="#reviews">Reviews</a>
         <a href="#faq">FAQ</a>
         <a href="#contact">Contact</a>
-        <a class="btn" href="tel:+19375550123" aria-label="Call Pristine Pets">(937) 555-0123</a>
+        <a class="btn" href="tel:+12098199644" aria-label="Call Pristine Pets">209.819.9644</a>
       </nav>
     </div>
   </header>
@@ -391,8 +395,8 @@
       <div class="row">
         <h3>Ready to pamper your pet?</h3>
         <div class="actions">
-          <a class="btn" href="tel:+19375550123">Call (937) 555-0123</a>
-          <a class="btn btn-outline" href="mailto:hello@pristinepets.org?subject=Grooming%20Inquiry&body=Hi%20Pristine%20Pets%2C%0A%0APet%20name%3A%0ABreed%2FSize%3A%0AServices%20interested%20in%3A%0APreferred%20dates%2Ftimes%3A%0AAddress%3A%0A%0AThanks!">Email us</a>
+          <a class="btn" href="tel:+12098199644">Call 209.819.9644</a>
+          <a class="btn btn-outline" href="mailto:support@pristinepets.org?subject=Grooming%20Inquiry&body=Hi%20Pristine%20Pets%2C%0A%0APet%20name%3A%0ABreed%2FSize%3A%0AServices%20interested%20in%3A%0APreferred%20dates%2Ftimes%3A%0AAddress%3A%0A%0AThanks!">Email us</a>
         </div>
       </div>
       <p class="tiny" style="margin:8px 0 0 0">Text available upon request • Same-week spots go fast</p>


### PR DESCRIPTION
## Summary
- Update site phone number to 209.819.9644 and email to support@pristinepets.org
- Add a subtle paw-print pattern to the page background for visual interest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b30baf24832fb8a2d41e0dd46c31