### PR TITLE
Replace van section with mockup image

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,39 +99,10 @@
       position:absolute;inset:auto -120px -140px auto;opacity:.12;pointer-events:none;transform:rotate(-8deg) scale(1.05)
     }
     @media (min-width:980px){ .paws{right:-80px;bottom:-100px} }
-    .hero-van{
+    .van-img{
       border-radius:calc(var(--radius) + 6px);
-      background:#0e58ff;
-      padding:22px;
-      position:relative;
       box-shadow:var(--shadow);
-      color:#fff;
-      min-height:320px;
-      display:flex;align-items:flex-end;justify-content:center;
-      overflow:hidden;
     }
-    .hero-van .caption{position:absolute;top:18px;left:18px;font-weight:700;letter-spacing:.02em}
-    /* White paw decals */
-    .hero-van:before, .hero-van:after{
-      content:"";position:absolute;background-repeat:repeat;opacity:.25;pointer-events:none
-    }
-    .hero-van:before{
-      inset:-60px -20px -20px -60px;
-      background-image: url('data:image/svg+xml;utf8,<?xml version="1.0" ?><svg xmlns="http://www.w3.org/2000/svg" width="140" height="140" viewBox="0 0 140 140"><g fill="%23ffffff"><circle cx="36" cy="20" r="10"/><circle cx="20" cy="36" r="10"/><circle cx="52" cy="34" r="10"/><circle cx="34" cy="52" r="10"/><path d="M70 78c-10 0-22 10-22 20 0 6 6 12 22 12s22-6 22-12c0-10-12-20-22-20z"/></g></svg>');
-      background-size:140px 140px;
-      transform:rotate(-15deg);
-    }
-    .hero-van:after{
-      inset:-50px -10px -10px -30px;
-      background-image: url('data:image/svg+xml;utf8,<?xml version="1.0" ?><svg xmlns="http://www.w3.org/2000/svg" width="110" height="110" viewBox="0 0 110 110"><g fill="%23ffffff"><circle cx="26" cy="10" r="8"/><circle cx="10" cy="26" r="8"/><circle cx="42" cy="24" r="8"/><circle cx="24" cy="42" r="8"/><path d="M55 63c-8 0-18 8-18 16 0 5 5 10 18 10s18-5 18-10c0-8-10-16-18-16z"/></g></svg>');
-      background-size:110px 110px;
-      transform:rotate(8deg);
-    }
-    .van-card{
-      background:#fff;color:#0b1a3d;border-radius:14px;padding:16px 18px;box-shadow:var(--shadow);width:min(540px, 100%);margin:14px auto;display:grid;gap:8px
-    }
-    .van-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-    .tag{display:inline-block;padding:8px 10px;border-radius:999px;background:#eef3ff;color:var(--brand-ink);font-weight:700;font-size:.9rem}
 
     /* Services */
     .tiles{display:grid;gap:16px}
@@ -227,18 +198,7 @@
         </div>
       </div>
 
-      <div class="hero-van" aria-label="Blue grooming van with white paw decals">
-        <div class="caption">Pristine Pets • Mobile Pet Spa</div>
-        <div class="van-card">
-          <div class="van-grid">
-            <div><span class="tag">Hydro-bath</span></div>
-            <div><span class="tag">Hand blow-dry</span></div>
-            <div><span class="tag">Clipping & scissoring</span></div>
-            <div><span class="tag">Sanitary tidy</span></div>
-          </div>
-          <div class="tiny" style="margin-top:4px">Serving Tipp City • Huber Heights • Surrounding areas</div>
-        </div>
-      </div>
+        <img src="Van Mock-up.jpg" alt="Pristine Pets Mobile Pet Spa van" class="van-img" />
       <svg class="paws" width="520" height="520" viewBox="0 0 120 120" aria-hidden="true">
         <g fill="#0e58ff">
           <circle cx="16" cy="18" r="6"/><circle cx="28" cy="8" r="6"/><circle cx="40" cy="18" r="6"/><circle cx="28" cy="28" r="6"/>


### PR DESCRIPTION
## Summary
- Replace custom van markup with new mock-up image
- Simplify styles by removing unused van-related rules and adding `.van-img`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899beef7670832fa414c5ae15cbb88a