### PR TITLE
Align hero image beside hero text

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       50% {background-position:100% 50%;}
       100% {background-position:0% 50%;}
     }
-    .hero .container{display:grid;gap:28px;align-items:center}
+    .hero .container{display:grid;gap:28px;align-items:center;max-width:1300px}
     @media (min-width:980px){ .hero .container{grid-template-columns:1.15fr .85fr;gap:40px} }
 
     .hero-card{
@@ -196,10 +196,10 @@
           <div class="kpi"><strong>No crates</strong><span class="tiny">Calm & hygienic</span></div>
           <div class="kpi"><strong>We come to you</strong><span class="tiny">Zero travel</span></div>
         </div>
-         <img src="Van Mock-up.jpg" alt="Pristine Pets Mobile Pet Spa van" class="van-img" />
       </div>
 
-       
+      <img src="Van Mock-up.jpg" alt="Pristine Pets Mobile Pet Spa van" class="van-img" />
+
       <svg class="paws" width="520" height="520" viewBox="0 0 120 120" aria-hidden="true">
         <g fill="#0e58ff">
           <circle cx="16" cy="18" r="6"/><circle cx="28" cy="8" r="6"/><circle cx="40" cy="18" r="6"/><circle cx="28" cy="28" r="6"/>


### PR DESCRIPTION
## Summary
- Move van image into its own grid column so it displays to the right of hero content
- Expand hero container width for improved side-by-side layout

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c87472b4832fa4979fce65f7b41c